### PR TITLE
Mod data stored in the savegame (no more xml and cloud support)

### DIFF
--- a/TLM/TLM/Mod.cs
+++ b/TLM/TLM/Mod.cs
@@ -29,7 +29,38 @@ namespace TrafficManager
         {
             get { return "Manage traffic junctions"; }
         }
+
+		public void ResetInGameData(bool value) {
+			TMTemporaryOptions.Instance().ResetSaveData = value;
+		}
+
+		public void OnSettingsUI(UIHelperBase helper)
+		{
+			UIHelperBase group = helper.AddGroup("Traffic Manager");
+			group.AddCheckbox("Reset in game data", false, ResetInGameData);
+
+		}
     }
+
+	/* Just a temporary solution for "reset in save data" option. If the in save data works,
+	 * we have to put this in real option class. Atm the value is resetted to false everytime
+	 * the user starts the game. */
+	public class TMTemporaryOptions {
+
+		private static TMTemporaryOptions instance = null;
+
+		public bool ResetSaveData { get; set; }
+
+		private TMTemporaryOptions() {
+			this.ResetSaveData = false;
+		}
+
+		public static TMTemporaryOptions Instance() {
+			if (instance == null)
+				instance = new TMTemporaryOptions ();
+			return instance;
+		}
+	}
 
     public sealed class ThreadingExtension : ThreadingExtensionBase
     {

--- a/TLM/TLM/SerializableDataExtension.cs
+++ b/TLM/TLM/SerializableDataExtension.cs
@@ -20,18 +20,14 @@ namespace TrafficManager
 
         private static Timer _timer;
 
-        private static bool loaded = false;
-
         public void OnCreated(ISerializableData serializableData)
         {
             uniqueID = 0u;
             SerializableData = serializableData;
-            loaded = false;
         }
 
         public void OnReleased()
         {
-            loaded = false;
         }
 
         public static void GenerateUniqueID()


### PR DESCRIPTION
I've moved the mod data into the savegame.

The old xml data is imported, but the mod will not use it anymore after the first save.

On the "old" mod, if your savegame is broken, you have to delete che traffic manager xml files. Now you can use the "reset data" flag from the options panel.

Please test and approve this changes :smile_cat: 
